### PR TITLE
feat: surface unlabeled upload stats on dashboards

### DIFF
--- a/api/database/services.py
+++ b/api/database/services.py
@@ -910,7 +910,7 @@ def get_user_stats(db: "Session", user_id: UUID):
     validated_q = db.query(_models.HighQualityLabeledSplice.duration).filter(_models.HighQualityLabeledSplice.validator_id == user_id)
     hours_validated = sum_duration(validated_q) / 3600.0
 
-    return {
+    stats = {
         "recorded_count": recorded_count,
         "labeled_count": labeled_count,
         "validated_count": validated_count,
@@ -918,6 +918,86 @@ def get_user_stats(db: "Session", user_id: UUID):
         "hours_labeled": round(hours_labeled, 2),
         "hours_validated": round(hours_validated, 2),
     }
+    stats.update(get_user_upload_stats(db, user_id))
+    return stats
+
+
+def get_user_upload_stats(db: "Session", user_id: UUID):
+    """
+    Aggregate splice generation metrics for the media a user has uploaded.
+
+    Splices are tied to an upload through `UploadRecord.display_name` == `Splice.name`
+    (the shared normalized video name), so this walks every splice queue for the
+    user's upload names and totals how many segments were generated versus how many
+    are still awaiting a label.
+
+    Parameters:
+        user_id (UUID): The user whose uploaded media should be aggregated.
+
+    Returns:
+        dict: A mapping with:
+            uploaded_splices (int): Total splices generated across all of the user's uploads.
+            unlabeled_splices (int): Generated splices that are still unlabeled.
+            hours_uploaded (float): Total duration of every generated splice, in hours.
+            hours_unlabeled (float): Duration of the unlabeled splices, in hours.
+    """
+    def _sum_duration(rows):
+        total = 0.0
+        for row in rows:
+            try:
+                total += float(row.duration)
+            except (ValueError, TypeError):
+                pass
+        return total
+
+    empty = {
+        "uploaded_splices": 0,
+        "unlabeled_splices": 0,
+        "hours_uploaded": 0.0,
+        "hours_unlabeled": 0.0,
+    }
+
+    upload_names = [
+        row.display_name
+        for row in (
+            db.query(_models.UploadRecord.display_name)
+            .filter(_models.UploadRecord.user_id == user_id)
+            .all()
+        )
+        if row.display_name
+    ]
+    names = list(set(upload_names))
+    if not names:
+        return empty
+
+    def _count_and_seconds(model, *extra_filters):
+        query = db.query(model.duration).filter(model.name.in_(names))
+        for extra in extra_filters:
+            query = query.filter(extra)
+        rows = query.all()
+        return len(rows), _sum_duration(rows)
+
+    unlabeled_c, unlabeled_s = _count_and_seconds(_models.Splice)
+    labeled_c, labeled_s = _count_and_seconds(_models.LabeledSplice)
+    validated_c, validated_s = _count_and_seconds(_models.HighQualityLabeledSplice)
+    processing_c, processing_s = _count_and_seconds(_models.SpliceBeingProcessed)
+    processing_unlabeled_c, processing_unlabeled_s = _count_and_seconds(
+        _models.SpliceBeingProcessed,
+        _models.SpliceBeingProcessed.status == "un_labeled",
+    )
+
+    generated_count = unlabeled_c + labeled_c + validated_c + processing_c
+    generated_seconds = unlabeled_s + labeled_s + validated_s + processing_s
+    still_unlabeled_count = unlabeled_c + processing_unlabeled_c
+    still_unlabeled_seconds = unlabeled_s + processing_unlabeled_s
+
+    return {
+        "uploaded_splices": generated_count,
+        "unlabeled_splices": still_unlabeled_count,
+        "hours_uploaded": round(generated_seconds / 3600.0, 2),
+        "hours_unlabeled": round(still_unlabeled_seconds / 3600.0, 2),
+    }
+
 
 def get_user_activity(db: "Session", user_id: UUID, page: int, page_size: int):
     """

--- a/api/database/services.py
+++ b/api/database/services.py
@@ -1194,7 +1194,22 @@ def get_user_upload_records(db: "Session", user_id: UUID, page: int, page_size: 
     return total, records
 
 
-def get_splice_stats_for_video_names(db: "Session", video_names: list[str]):
+def get_splice_stats_for_video_names(db: "Session", user_id: UUID, video_names: list[str]):
+    """
+    Aggregate splice counts per video name for a single owner.
+
+    Splice ``name`` is derived from the user-supplied upload title and is not
+    globally unique, so every query is additionally scoped by ``owner_id`` to
+    avoid mixing in another user's splices that happen to share a name.
+
+    Parameters:
+        user_id (UUID): Owner whose splices should be counted.
+        video_names (list[str]): Upload names to aggregate counts for.
+
+    Returns:
+        dict: Mapping of video name to ``{total_generated, validated_count,
+        labeled_count, unlabeled_count}``.
+    """
     if not video_names:
         return {}
 
@@ -1214,7 +1229,7 @@ def get_splice_stats_for_video_names(db: "Session", video_names: list[str]):
 
     unlabeled_rows = (
         db.query(_models.Splice.name, func.count(_models.Splice.id))
-        .filter(_models.Splice.name.in_(unique_names))
+        .filter(_models.Splice.owner_id == user_id, _models.Splice.name.in_(unique_names))
         .group_by(_models.Splice.name)
         .all()
     )
@@ -1225,7 +1240,7 @@ def get_splice_stats_for_video_names(db: "Session", video_names: list[str]):
 
     labeled_rows = (
         db.query(_models.LabeledSplice.name, func.count(_models.LabeledSplice.id))
-        .filter(_models.LabeledSplice.name.in_(unique_names))
+        .filter(_models.LabeledSplice.owner_id == user_id, _models.LabeledSplice.name.in_(unique_names))
         .group_by(_models.LabeledSplice.name)
         .all()
     )
@@ -1236,7 +1251,7 @@ def get_splice_stats_for_video_names(db: "Session", video_names: list[str]):
 
     validated_rows = (
         db.query(_models.HighQualityLabeledSplice.name, func.count(_models.HighQualityLabeledSplice.id))
-        .filter(_models.HighQualityLabeledSplice.name.in_(unique_names))
+        .filter(_models.HighQualityLabeledSplice.owner_id == user_id, _models.HighQualityLabeledSplice.name.in_(unique_names))
         .group_by(_models.HighQualityLabeledSplice.name)
         .all()
     )
@@ -1251,7 +1266,7 @@ def get_splice_stats_for_video_names(db: "Session", video_names: list[str]):
             _models.SpliceBeingProcessed.status,
             func.count(_models.SpliceBeingProcessed.id),
         )
-        .filter(_models.SpliceBeingProcessed.name.in_(unique_names))
+        .filter(_models.SpliceBeingProcessed.owner_id == user_id, _models.SpliceBeingProcessed.name.in_(unique_names))
         .group_by(_models.SpliceBeingProcessed.name, _models.SpliceBeingProcessed.status)
         .all()
     )

--- a/api/database/services.py
+++ b/api/database/services.py
@@ -971,12 +971,14 @@ def get_user_upload_stats(db: "Session", user_id: UUID):
         return empty
 
     def _count_and_seconds(model, *extra_filters):
-        query = db.query(model.duration).filter(model.name.in_(names))
+        query = db.query(model.duration).filter(
+            model.owner_id == user_id,
+            model.name.in_(names)
+        )
         for extra in extra_filters:
             query = query.filter(extra)
         rows = query.all()
         return len(rows), _sum_duration(rows)
-
     unlabeled_c, unlabeled_s = _count_and_seconds(_models.Splice)
     labeled_c, labeled_s = _count_and_seconds(_models.LabeledSplice)
     validated_c, validated_s = _count_and_seconds(_models.HighQualityLabeledSplice)

--- a/api/main.py
+++ b/api/main.py
@@ -688,7 +688,7 @@ async def list_upload_history(
 ):
     total, records = _services.get_user_upload_records(db, current_user.id, page, page_size)
     names = [record.display_name for record in records if record.display_name]
-    stats_map = _services.get_splice_stats_for_video_names(db, names)
+    stats_map = _services.get_splice_stats_for_video_names(db, current_user.id, names)
 
     items = []
     for record in records:

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -151,7 +151,7 @@ def read_user_activity(
 ):
     total, rows = services.get_user_activity(db, current_user.id, page, page_size)
     names = [row.name for row in rows if getattr(row, "name", None)]
-    stats_map = services.get_splice_stats_for_video_names(db, names)
+    stats_map = services.get_splice_stats_for_video_names(db, current_user.id, names)
     items: list[dict] = []
 
     for row in rows:

--- a/web/app/my-labels/content.tsx
+++ b/web/app/my-labels/content.tsx
@@ -3,7 +3,7 @@ import { useSession } from "next-auth/react"
 import { useState, useEffect, ChangeEvent, ReactNode, useCallback } from "react"
 import { Container, Typography, Paper, Grid, Card, CardContent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Box, Chip, TextField, Button, FormControlLabel, Checkbox, Alert, TablePagination, CircularProgress } from "@mui/material"
 import { alpha } from "@mui/material/styles"
-import { CheckCircle, Mic, Clock, Activity, Edit3, Timer } from "lucide-react"
+import { CheckCircle, Mic, Clock, Activity, Edit3, Timer, Layers, CircleDashed, Hourglass } from "lucide-react"
 import axios from "axios"
 import Footer from "@/components/Sections/Footer"
 import { buildFileAccessUrl } from "@/lib/utils"
@@ -83,7 +83,11 @@ export default function MyLabelsPage() {
     validated_count: 0,
     hours_recorded: 0,
     hours_labeled: 0,
-    hours_validated: 0
+    hours_validated: 0,
+    uploaded_splices: 0,
+    unlabeled_splices: 0,
+    hours_uploaded: 0,
+    hours_unlabeled: 0
   })
   const [activity, setActivity] = useState<ActivityItem[]>([])
   const [activityPage, setActivityPage] = useState(0)
@@ -222,7 +226,11 @@ export default function MyLabelsPage() {
           validated_count: payload.validated_count ?? 0,
           hours_recorded: payload.hours_recorded ?? 0,
           hours_labeled: payload.hours_labeled ?? 0,
-          hours_validated: payload.hours_validated ?? 0
+          hours_validated: payload.hours_validated ?? 0,
+          uploaded_splices: payload.uploaded_splices ?? 0,
+          unlabeled_splices: payload.unlabeled_splices ?? 0,
+          hours_uploaded: payload.hours_uploaded ?? 0,
+          hours_unlabeled: payload.hours_unlabeled ?? 0
         })
       } catch (error) {
         console.error(error)
@@ -472,6 +480,50 @@ export default function MyLabelsPage() {
               value={stats.hours_validated.toFixed(2)}
               icon={<Activity size={28} />}
               color="#8B5CF6"
+            />
+          </Grid>
+        </Grid>
+
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h5" fontWeight={700} gutterBottom>
+          Your Uploads
+        </Typography>
+        <Typography variant="body2" color="textSecondary">
+          Every clip generated from the media you upload — including the segments no one has labeled yet.
+        </Typography>
+      </Box>
+
+        <Grid container spacing={3} sx={{ mb: 6 }}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <StatCard
+              title="Splices Generated"
+              value={stats.uploaded_splices}
+              icon={<Layers size={28} />}
+              color="#6366F1"
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <StatCard
+              title="Unlabeled Splices"
+              value={stats.unlabeled_splices}
+              icon={<CircleDashed size={28} />}
+              color="#F59E0B"
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <StatCard
+              title="Hours Uploaded"
+              value={stats.hours_uploaded.toFixed(2)}
+              icon={<Hourglass size={28} />}
+              color="#0EA5E9"
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <StatCard
+              title="Hours Unlabeled"
+              value={stats.hours_unlabeled.toFixed(2)}
+              icon={<Clock size={28} />}
+              color="#EAB308"
             />
           </Grid>
         </Grid>

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -149,9 +149,17 @@
     "validatedHours": "Validated Hours",
     "labeledHours": "Labeled Hours",
     "totalValidated": "Total Validated",
+    "totalUnlabeled": "Total Unlabeled",
+    "unlabeledHours": "Unlabeled Hours",
+    "grandTotal": "Grand Total",
+    "grandTotalHelp": "All audio collected across every stage.",
+    "totalClips": "Total Clips",
+    "totalHours": "Total Hours",
     "labeledSubtitle": "{percent}% of total clips",
+    "unlabeledSubtitle": "{percent}% of total clips",
     "validatedHoursSubtitle": "Hours of high-quality audio",
     "labeledHoursSubtitle": "Total hours transcribed",
+    "unlabeledHoursSubtitle": "Hours awaiting transcription",
     "totalValidatedSubtitle": "Total clips validated"
   },
   "footer": {

--- a/web/messages/sq.json
+++ b/web/messages/sq.json
@@ -149,9 +149,17 @@
     "validatedHours": "Orë të validuara",
     "labeledHours": "Orë të etiketuara",
     "totalValidated": "Totali i validimeve",
+    "totalUnlabeled": "Totali i paetiketuara",
+    "unlabeledHours": "Orë të paetiketuara",
+    "grandTotal": "Totali i përgjithshëm",
+    "grandTotalHelp": "I gjithë audio i mbledhur në çdo fazë.",
+    "totalClips": "Klipet totale",
+    "totalHours": "Orë totale",
     "labeledSubtitle": "{percent}% e klipëve gjithsej",
+    "unlabeledSubtitle": "{percent}% e klipëve gjithsej",
     "validatedHoursSubtitle": "Orë audio me cilësi të lartë",
     "labeledHoursSubtitle": "Orë të transkriptuara",
+    "unlabeledHoursSubtitle": "Orë në pritje për transkriptim",
     "totalValidatedSubtitle": "Klipet totale të validuara"
   },
   "footer": {

--- a/web/src/components/Sections/Statistics.tsx
+++ b/web/src/components/Sections/Statistics.tsx
@@ -85,12 +85,11 @@ export default function Statistics() {
   );
 
   const grandTotalClips = summaryInfo
-    ? summaryInfo.total_labeled + summaryInfo.total_unlabeled + summaryInfo.total_validated
+    ? (summaryInfo.total_labeled ?? 0) + (summaryInfo.total_unlabeled ?? 0) + (summaryInfo.total_validated ?? 0)
     : 0;
   const grandTotalHours = summaryInfo
-    ? summaryInfo.total_duration_labeled + summaryInfo.total_duration_unlabeled + summaryInfo.total_duration_validated
+    ? (summaryInfo.total_duration_labeled ?? 0) + (summaryInfo.total_duration_unlabeled ?? 0) + (summaryInfo.total_duration_validated ?? 0)
     : 0;
-
   return (
     <Box sx={{ py: 10, bgcolor: 'grey.50' }}>
       <Container maxWidth="lg">

--- a/web/src/components/Sections/Statistics.tsx
+++ b/web/src/components/Sections/Statistics.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from "react";
 import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 import { Typography, Grid, Box, Container, Paper } from "@mui/material";
-import { Database, CheckCircle, Clock, ClipboardCheck } from "lucide-react";
+import { Database, CheckCircle, Clock, ClipboardCheck, CircleDashed, Hourglass, Layers } from "lucide-react";
 import axios from "axios";
 import { useTranslations } from "next-intl";
 
@@ -84,6 +84,13 @@ export default function Statistics() {
     </Paper>
   );
 
+  const grandTotalClips = summaryInfo
+    ? summaryInfo.total_labeled + summaryInfo.total_unlabeled + summaryInfo.total_validated
+    : 0;
+  const grandTotalHours = summaryInfo
+    ? summaryInfo.total_duration_labeled + summaryInfo.total_duration_unlabeled + summaryInfo.total_duration_validated
+    : 0;
+
   return (
     <Box sx={{ py: 10, bgcolor: 'grey.50' }}>
       <Container maxWidth="lg">
@@ -125,42 +132,109 @@ export default function Statistics() {
                 <Grid size={{ xs: 12, md: 8 }}>
                     <Grid container spacing={3}>
                         <Grid size={{ xs: 12, sm: 6 }}>
-                            <StatCard 
-                                title={t("totalLabeled")} 
-                                value={summaryInfo.total_labeled.toLocaleString()} 
+                            <StatCard
+                                title={t("totalLabeled")}
+                                value={summaryInfo.total_labeled.toLocaleString()}
                                 subtitle={t("labeledSubtitle", { percent: summaryInfo.sumofLabeled.toFixed(1) })}
                                 icon={<Database size={24} />}
                                 color="#3B82F6"
                             />
                         </Grid>
                         <Grid size={{ xs: 12, sm: 6 }}>
-                            <StatCard 
-                                title={t("validatedHours")}
-                                value={summaryInfo.total_duration_validated.toFixed(1)} 
-                                subtitle={t("validatedHoursSubtitle")}
-                                icon={<CheckCircle size={24} />}
-                                color="#10B981"
-                            />
-                        </Grid>
-                        <Grid size={{ xs: 12, sm: 6 }}>
-                            <StatCard 
+                            <StatCard
                                 title={t("labeledHours")}
-                                value={summaryInfo.total_duration_labeled.toFixed(1)} 
+                                value={summaryInfo.total_duration_labeled.toFixed(1)}
                                 subtitle={t("labeledHoursSubtitle")}
                                 icon={<Clock size={24} />}
                                 color="#F59E0B"
                             />
                         </Grid>
                         <Grid size={{ xs: 12, sm: 6 }}>
-                            <StatCard 
+                            <StatCard
+                                title={t("totalUnlabeled")}
+                                value={summaryInfo.total_unlabeled.toLocaleString()}
+                                subtitle={t("unlabeledSubtitle", { percent: summaryInfo.sumofUnLabeled.toFixed(1) })}
+                                icon={<CircleDashed size={24} />}
+                                color="#EF4444"
+                            />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6 }}>
+                            <StatCard
+                                title={t("unlabeledHours")}
+                                value={summaryInfo.total_duration_unlabeled.toFixed(1)}
+                                subtitle={t("unlabeledHoursSubtitle")}
+                                icon={<Hourglass size={24} />}
+                                color="#F97316"
+                            />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6 }}>
+                            <StatCard
                                 title={t("totalValidated")}
-                                value={summaryInfo.total_validated?.toLocaleString() || "0"} 
+                                value={summaryInfo.total_validated?.toLocaleString() || "0"}
                                 subtitle={t("totalValidatedSubtitle")}
                                 icon={<ClipboardCheck size={24} />}
                                 color="#8B5CF6"
                             />
                         </Grid>
+                        <Grid size={{ xs: 12, sm: 6 }}>
+                            <StatCard
+                                title={t("validatedHours")}
+                                value={summaryInfo.total_duration_validated.toFixed(1)}
+                                subtitle={t("validatedHoursSubtitle")}
+                                icon={<CheckCircle size={24} />}
+                                color="#10B981"
+                            />
+                        </Grid>
                     </Grid>
+                </Grid>
+
+                <Grid size={{ xs: 12 }}>
+                    <Paper
+                        elevation={0}
+                        sx={{
+                            p: { xs: 3, md: 4 },
+                            borderRadius: 4,
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            background: 'linear-gradient(120deg, rgba(166,77,74,0.06) 0%, rgba(255,142,83,0.06) 100%)',
+                            display: 'flex',
+                            flexDirection: { xs: 'column', sm: 'row' },
+                            alignItems: { xs: 'flex-start', sm: 'center' },
+                            gap: 3,
+                        }}
+                    >
+                        <Box sx={{ display: 'flex', alignItems: 'center', minWidth: { sm: 220 } }}>
+                            <Box sx={{ p: 1.5, borderRadius: 2, bgcolor: 'rgba(166,77,74,0.12)', color: '#A64D4A', mr: 2, display: 'flex' }}>
+                                <Layers size={24} />
+                            </Box>
+                            <Box>
+                                <Typography variant="h6" fontWeight={700} color="textPrimary">
+                                    {t("grandTotal")}
+                                </Typography>
+                                <Typography variant="body2" color="textSecondary">
+                                    {t("grandTotalHelp")}
+                                </Typography>
+                            </Box>
+                        </Box>
+                        <Box sx={{ display: 'flex', gap: { xs: 4, sm: 6 }, flexWrap: 'wrap' }}>
+                            <Box>
+                                <Typography variant="h3" fontWeight={800} sx={{ background: 'linear-gradient(45deg, #A64D4A, #FF8E53)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
+                                    {grandTotalClips.toLocaleString()}
+                                </Typography>
+                                <Typography variant="body2" color="textSecondary" fontWeight={600}>
+                                    {t("totalClips")}
+                                </Typography>
+                            </Box>
+                            <Box>
+                                <Typography variant="h3" fontWeight={800} sx={{ background: 'linear-gradient(45deg, #A64D4A, #FF8E53)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
+                                    {grandTotalHours.toFixed(1)}
+                                </Typography>
+                                <Typography variant="body2" color="textSecondary" fontWeight={600}>
+                                    {t("totalHours")}
+                                </Typography>
+                            </Box>
+                        </Box>
+                    </Paper>
                 </Grid>
             </Grid>
         )}


### PR DESCRIPTION
User and platform dashboards only counted personal labeling/validation work, so uploads that generate splices showed 0. Add the raw generated and still-unlabeled totals in both places.

- api: get_user_upload_stats() joins upload_records to every splice queue by video name; /users/stats now returns uploaded_splices, unlabeled_splices, hours_uploaded, hours_unlabeled (read-only aggregation, no new columns)
- My Dashboard: add "Your Uploads" section (Splices Generated, Unlabeled Splices, Hours Uploaded, Hours Unlabeled)
- Main/Statistics: add Total Unlabeled + Unlabeled Hours cards and a Grand Total banner (Total Clips / Total Hours); shown on the landing, validate, and record pages
- i18n: add stats keys to en.json and sq.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Your Uploads” dashboard section showing generated splices, unlabeled splices, uploaded hours, and unlabeled hours.
  * Expanded the statistics area with unlabeled content metrics and new grand totals for clips and hours.
  * Added/updated English and Albanian labels, help text, and subtitles for these new stats.
* **Bug Fixes**
  * Fixed user activity and upload history statistics to be correctly scoped to the authenticated user, preventing mixed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->