### PR TITLE
fix: persist prod audio in named volumes so deploys stop wiping splices

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,9 +72,6 @@ jobs:
           ENVIRONMENT=production
           EOF
 
-      - name: Create Audio Directories
-        run: |
-          mkdir -p audio_files/mp3 audio_files/mp4 audio_files/splices
 
       - name: Stop Existing Containers
         run: |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,10 +52,15 @@ services:
       context: .
       dockerfile: ./api/dockerfiles/Dockerfile.prod
     restart: always
+    # Audio assets MUST live in named volumes, not checkout-relative bind mounts.
+    # The deploy runs `actions/checkout` (git clean -ffdx) which wipes the
+    # gitignored ./audio_files tree on every push, orphaning splice DB rows.
+    # Named volumes are docker-managed and survive `checkout`, `compose down`,
+    # and rebuilds - the same guarantee postgres_data_prod already relies on.
     volumes:
-      - ./audio_files/mp3:/code/mp3
-      - ./audio_files/mp4:/code/mp4
-      - ./audio_files/splices:/code/splices
+      - audio_mp3_prod:/code/mp3
+      - audio_mp4_prod:/code/mp4
+      - audio_splices_prod:/code/splices
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -144,5 +149,10 @@ networks:
 # ============================================
 # Volumes
 # ============================================
+# All persistent state uses named volumes so it survives deploys, which run
+# `actions/checkout` (git clean) against the repo working tree.
 volumes:
   postgres_data_prod:
+  audio_mp3_prod:
+  audio_mp4_prod:
+  audio_splices_prod:


### PR DESCRIPTION
Prod bind-mounted ./audio_files/{mp3,mp4,splices}, but audio_files is gitignored and the deploy runs actions/checkout (git clean -ffdx), which deleted every splice/source WAV on each push. Postgres lives in a named volume, so the splice rows survived — leaving DB records that 404 on playback (only the sample video re-seeds itself on startup).

Move mp3/mp4/splices to named volumes (audio_{mp3,mp4,splices}_prod), matching postgres_data_prod, and drop the now-unused "Create Audio Directories" deploy step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployments by preserving uploaded audio assets across container rebuilds and redeployments.
  * Prevented deployment cleanup steps from inadvertently orphaning stored audio files.

* **Chores**
  * Streamlined the production deployment workflow with container health verification and failure logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->